### PR TITLE
Link PDFs, updated search cards

### DIFF
--- a/transgov/src/prototype/src/components/Result.vue
+++ b/transgov/src/prototype/src/components/Result.vue
@@ -92,27 +92,20 @@ export default{
       // basic query for es; for now searching 'exact term' over all fields
       const query = {
         query: {
-          match_phrase: {
-            '_all': {
-              'query': this.inputField.search,
-              'prefix_length': '3',
-              'fuzziness': '2',
-              'operator': 'and'
+          multi_match: {
+            'query': this.inputField.search,
+            'type': 'cross_fields',
+            'fields' : [ '_all' ],
+            'fuzziness': '2',
+            'operator': 'and',
             }
-            // this.inputField.search
-          }
+
         },
         'highlight': {
           'fields': {
-            'title': {
-              'no_match_size': 300,
-              'number_of_fragments': 0
+            '*': {
+
             },
-            'description': {
-              'fragment_size': 300,
-              'no_match_size': 500,
-              'number_of_fragments': 5
-            }
           }
         }
       }

--- a/transgov/src/prototype/src/components/SearchResultList.vue
+++ b/transgov/src/prototype/src/components/SearchResultList.vue
@@ -5,7 +5,10 @@
       <b-col>
         <!-- <SearchResult v-for="(searchresult, index) in test" :key="index" v-bind:searchresult="searchresult" v-bind:id="searchresult.id">
         </SearchResult> -->
-        <b-card no-body header-tag="header" footer-tag="footer" class="md-elevation-3">
+        <b-card no-body header-tag="header" footer-tag="footer" class="md-elevation-3" 
+          border-variant="dark"
+          header-bg-variant="dark"
+          header-text-variant="white">
           
           <!-- We use a highlighted title if available, otherwise the regular title -->
           <h6 v-if="searchresult.highlight.Title" slot="header" class="mb-0">
@@ -21,15 +24,40 @@
             </router-link>
           </h6>
           
-          <!-- Match content, attempts to show all matches in a document -->
-          <p class="card-text clamp-3" v-for="(matches, category) in searchresult.highlight">
-            <ul>
-              <li>{{ category.slice(0,6) == "Items." ? category.slice(6) : category }}</li>
-              <ul>
-                <li v-for="match in matches"><span v-html="match"></span></li>
-              </ul>
-            </ul>
-          </p>
+          
+          <!-- Tabs allow the matches for a result to be shown, but then also the meta data if they want to drill down -->
+          <b-tabs card id="tabs-lvl-1">
+            <b-tab title="Highlights">
+                <!-- Match content, attempts to show all matches in a document, with highlights -->
+                <p class="card-text clamp-3" v-for="(matches, category) in searchresult.highlight">
+                  <ul>
+                    <li>{{ category.slice(0,6) == "Items." ? category.slice(6) : category }}</li>
+                    <ul>
+                      <li v-for="match in matches"><span v-html="match"></span></li>
+                    </ul>
+                  </ul>
+                </p>
+            </b-tab>
+            <b-tab title="Attendees">
+                <p class="card-text" >
+                  <ul>
+                    <li v-for="attendee in searchresult._source.Attendees">{{attendee}}</li>
+                  </ul>
+                </p>
+            </b-tab>
+            <div id="TETETETSTSADUGAIDADBAOI">
+            <b-tab title="Items" no-body >
+                <b-tabs card>
+                  <template v-for="item in searchresult._source.Items">
+                    <b-tab :title="'Item ' + item['Item No.']">
+                      Tab Contents 1
+                    </b-tab>
+                  </template>
+                </b-tabs>
+            </b-tab>
+            </div>
+          </b-tabs>
+          
         </b-card>
         <!-- Upgraded version in the works
         <b-card no-body header-tag="header" footer-tag="footer" class="md-elevation-3">
@@ -91,4 +119,14 @@ em{
   font-weight: bold;
   background-color: #FFFFCC;
 }
+#tabs-lvl-1>.card-header{
+  background-color: #e1e3e3;
+}
+.card-header em{
+  background-color: #686b00;
+}
+#tabs-lvl-1>.card-header>ul>li:nth-child(3)>a.active{
+  background-color: #f7f7f7;
+  border-bottom-color: #f7f7f7;
+  }
 </style>

--- a/transgov/src/prototype/src/components/SearchResultList.vue
+++ b/transgov/src/prototype/src/components/SearchResultList.vue
@@ -1,60 +1,69 @@
 <template>
   <div id="search-result-list">
     <!-- This is a sub-component, the parent should declare a container for it -->
-    <b-card no-body>
-      <b-tabs card>
-        <b-tab title="Tab 1" active>
-          Tab Contents 1
-        </b-tab>
-        <b-tab title="Tab 2">
-          Tab Contents 2
-        </b-tab>
-      </b-tabs>
-    </b-card>
     <b-row v-for="(searchresult, index) in test" :key="index" v-bind:id="searchresult.id" class="mt-4" no-gutters>
       <b-col>
         <!-- <SearchResult v-for="(searchresult, index) in test" :key="index" v-bind:searchresult="searchresult" v-bind:id="searchresult.id">
         </SearchResult> -->
         <b-card no-body header-tag="header" footer-tag="footer" class="md-elevation-3">
-          <!-- <h6 slot="header" class="mb-0"><span class="title">{{ searchresult._source.title }}</span></h6>
-          <p class="card-text clamp-3">
-            <span class="desc">{{ searchresult._source.description }}</span>
-          </p> -->
           
-          <!--
-          <h6 v-if= searchresult slot="header" class="mb-0" v-for="title in searchresult._source.Title">
-            <span class="title" v-html="title"></span>
-            <router-link :to="{name: 'View PDF', params: { file_id:'file_id:' + searchresult._source.django_id}}">
-            See more
+          <!-- We use a highlighted title if available, otherwise the regular title -->
+          <h6 v-if="searchresult.highlight.Title" slot="header" class="mb-0">
+            <span class="title" v-html="searchresult.highlight.Title[0]"></span>
+            <router-link :to="{name: 'View PDF', params: { file_id:searchresult._source.url}}">
+            View Original PDF
             </router-link>
           </h6>
-          -->
-          <!--
-          <p class="card-text clamp-3" v-for="desc in searchresult._source.items">
-            <span class="desc" v-html="desc"></span>
+          <h6 v-else slot="header" class="mb-0">
+            {{searchresult._source.Title}}
+            <router-link :to="{name: 'View PDF', params: { file_id:searchresult._source.url}}">
+            View Original PDF
+            </router-link>
+          </h6>
+          
+          <!-- Match content, attempts to show all matches in a document -->
+          <p class="card-text clamp-3" v-for="(matches, category) in searchresult.highlight">
+            <ul>
+              <li>{{ category.slice(0,6) == "Items." ? category.slice(6) : category }}</li>
+              <ul>
+                <li v-for="match in matches"><span v-html="match"></span></li>
+              </ul>
+            </ul>
           </p>
-          -->
+        </b-card>
+        <!-- Upgraded version in the works
+        <b-card no-body header-tag="header" footer-tag="footer" class="md-elevation-3">
           <h6 v-if= searchresult slot="header" class="mb-0">
             {{searchresult._source.Title}}
             <router-link :to="{name: 'View PDF', params: { file_id:searchresult._source.url}}">
-            See more
+            View Original PDF
             </router-link>
           </h6>
           <b-tabs card>
+            <b-tab title="Highlights">
+                If highlights start working put them in here, otherwise comment out this tab
+            </b-tab>
+            <b-tab title="Attendees">
+                If highlights start working put them in here, otherwise comment out this tab
+            </b-tab>
+            <b-tab title="Items" no-body>
+                <b-tabs card>
+                  <b-tab title="Tab 1" active>
+                    Tab Contents 1
+                  </b-tab>
+                  <b-tab title="Tab 2">
+                    Tab Contents 2
+                  </b-tab>
+                </b-tabs>
+            </b-tab>
             <div v-for="desc in searchresult._source.Items">
               <b-tab title="Tab 1">
                 Tab Contents 1
               </b-tab>
             </div>
           </b-tabs>
-          <!--
-          <p class="card-text clamp-3" v-for="desc in searchresult._source.Items">
-            <span class="desc" v-html="desc"></span>
-          </p>
-          -->
-          
-
         </b-card>
+        -->
       </b-col>
     </b-row>
   </div>

--- a/transgov/src/prototype/src/components/SearchResultList.vue
+++ b/transgov/src/prototype/src/components/SearchResultList.vue
@@ -1,25 +1,58 @@
 <template>
   <div id="search-result-list">
     <!-- This is a sub-component, the parent should declare a container for it -->
+    <b-card no-body>
+      <b-tabs card>
+        <b-tab title="Tab 1" active>
+          Tab Contents 1
+        </b-tab>
+        <b-tab title="Tab 2">
+          Tab Contents 2
+        </b-tab>
+      </b-tabs>
+    </b-card>
     <b-row v-for="(searchresult, index) in test" :key="index" v-bind:id="searchresult.id" class="mt-4" no-gutters>
       <b-col>
         <!-- <SearchResult v-for="(searchresult, index) in test" :key="index" v-bind:searchresult="searchresult" v-bind:id="searchresult.id">
         </SearchResult> -->
-        <b-card header-tag="header" footer-tag="footer" class="md-elevation-3">
+        <b-card no-body header-tag="header" footer-tag="footer" class="md-elevation-3">
           <!-- <h6 slot="header" class="mb-0"><span class="title">{{ searchresult._source.title }}</span></h6>
           <p class="card-text clamp-3">
             <span class="desc">{{ searchresult._source.description }}</span>
           </p> -->
           
-          <h6 v-if= searchresult slot="header" class="mb-0" v-for="title in searchresult.highlight.title">
+          <!--
+          <h6 v-if= searchresult slot="header" class="mb-0" v-for="title in searchresult._source.Title">
             <span class="title" v-html="title"></span>
             <router-link :to="{name: 'View PDF', params: { file_id:'file_id:' + searchresult._source.django_id}}">
             See more
             </router-link>
           </h6>
-          <p class="card-text clamp-3" v-for="desc in searchresult.highlight.description">
+          -->
+          <!--
+          <p class="card-text clamp-3" v-for="desc in searchresult._source.items">
             <span class="desc" v-html="desc"></span>
           </p>
+          -->
+          <h6 v-if= searchresult slot="header" class="mb-0">
+            {{searchresult._source.Title}}
+            <router-link :to="{name: 'View PDF', params: { file_id:searchresult._source.url}}">
+            See more
+            </router-link>
+          </h6>
+          <b-tabs card>
+            <div v-for="desc in searchresult._source.Items">
+              <b-tab title="Tab 1">
+                Tab Contents 1
+              </b-tab>
+            </div>
+          </b-tabs>
+          <!--
+          <p class="card-text clamp-3" v-for="desc in searchresult._source.Items">
+            <span class="desc" v-html="desc"></span>
+          </p>
+          -->
+          
 
         </b-card>
       </b-col>

--- a/transgov/src/prototype/src/components/SearchResultList.vue
+++ b/transgov/src/prototype/src/components/SearchResultList.vue
@@ -45,17 +45,18 @@
                   </ul>
                 </p>
             </b-tab>
-            <div id="TETETETSTSADUGAIDADBAOI">
+            <!-- CSS rules to handle the nested tabs rely on this being the 3rd tab, if you need to rearrange then change the rule -->
             <b-tab title="Items" no-body >
                 <b-tabs card>
                   <template v-for="item in searchresult._source.Items">
-                    <b-tab :title="'Item ' + item['Item No.']">
-                      Tab Contents 1
+                    <b-tab :title="'Item ' + item['Item No.']" no-body>
+                      <b-list-group flush>
+                        <b-list-group-item v-for="(val, attrib) in item"><strong>{{attrib}}</strong>: {{val}}</b-list-group-item>
+                      </b-list-group>
                     </b-tab>
                   </template>
                 </b-tabs>
             </b-tab>
-            </div>
           </b-tabs>
           
         </b-card>

--- a/transgov/src/prototype/src/components/ViewPDF.vue
+++ b/transgov/src/prototype/src/components/ViewPDF.vue
@@ -20,7 +20,7 @@
         </b-col>
         -->
         <b-col>
-          <p>We recieved this file ID: {{file_id.slice(8)}}</p>
+          <p>We recieved this file ID: {{file_id}}</p>
           <div>
             <input type="checkbox" v-model="show">
             <select v-model="src" style="width: 30em">
@@ -32,7 +32,7 @@
             <button @click="$refs.pdf.print()">print</button>
             <div style="width: 50%">
               <div v-if="loadedRatio > 0 && loadedRatio < 1" style="background-color: green; color: white; text-align: center" :style="{ width: loadedRatio * 100 + '%' }">{{ Math.floor(loadedRatio * 100) }}%</div>
-              <pdf v-if="show" ref="pdf" style="border: 1px solid red" :src="src" :page="page" :rotate="rotate" @password="password" @progress="loadedRatio = $event" @error="error" @num-pages="numPages = $event"></pdf>
+              <pdf v-if="show" ref="pdf" style="border: 1px solid red" :src="file_id" :page="page" :rotate="rotate" @password="password" @progress="loadedRatio = $event" @error="error" @num-pages="numPages = $event"></pdf>
             </div>
           </div>
         </b-col>
@@ -66,15 +66,7 @@ export default{
     return {
       ElasticResult: {},
       show: true,
-      pdfList: [
-        '',
-        'https://cdn.mozilla.net/pdfjs/tracemonkey.pdf',
-        'https://cdn.rawgit.com/mozilla/pdf.js/c6e8ca86/test/pdfs/freeculture.pdf',
-        'https://cdn.rawgit.com/mozilla/pdf.js/c6e8ca86/test/pdfs/annotation-link-text-popup.pdf',
-        'https://cdn.rawgit.com/mozilla/pdf.js/c6e8ca86/test/pdfs/calrgb.pdf',
-        'https://cdn.rawgit.com/sayanee/angularjs-pdf/68066e85/example/pdf/relativity.protected.pdf',
-        'data:application/pdf;base64,JVBERi0xLjUKJbXtrvsKMyAwIG9iago8PCAvTGVuZ3RoIDQgMCBSCiAgIC9GaWx0ZXIgL0ZsYXRlRGVjb2RlCj4+CnN0cmVhbQp4nE2NuwoCQQxF+/mK+wMbk5lkHl+wIFislmIhPhYEi10Lf9/MVgZCAufmZAkMppJ6+ZLUuFWsM3ZXxvzpFNaMYjEriqpCtbZSBOsDzw0zjqPHZYtTrEmz4eto7/0K54t7GfegOGCBbBdDH3+y2zsMsVERc9SoRkXORqKGJupS6/9OmMIUfgypJL4KZW5kc3RyZWFtCmVuZG9iago0IDAgb2JqCiAgIDEzOAplbmRvYmoKMiAwIG9iago8PAogICAvRXh0R1N0YXRlIDw8CiAgICAgIC9hMCA8PCAvQ0EgMC42MTE5ODcgL2NhIDAuNjExOTg3ID4+CiAgICAgIC9hMSA8PCAvQ0EgMSAvY2EgMSA+PgogICA+Pgo+PgplbmRvYmoKNSAwIG9iago8PCAvVHlwZSAvUGFnZQogICAvUGFyZW50IDEgMCBSCiAgIC9NZWRpYUJveCBbIDAgMCA1OTUuMjc1NTc0IDg0MS44ODk3NzEgXQogICAvQ29udGVudHMgMyAwIFIKICAgL0dyb3VwIDw8CiAgICAgIC9UeXBlIC9Hcm91cAogICAgICAvUyAvVHJhbnNwYXJlbmN5CiAgICAgIC9DUyAvRGV2aWNlUkdCCiAgID4+CiAgIC9SZXNvdXJjZXMgMiAwIFIKPj4KZW5kb2JqCjEgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzCiAgIC9LaWRzIFsgNSAwIFIgXQogICAvQ291bnQgMQo+PgplbmRvYmoKNiAwIG9iago8PCAvQ3JlYXRvciAoY2Fpcm8gMS4xMS4yIChodHRwOi8vY2Fpcm9ncmFwaGljcy5vcmcpKQogICAvUHJvZHVjZXIgKGNhaXJvIDEuMTEuMiAoaHR0cDovL2NhaXJvZ3JhcGhpY3Mub3JnKSkKPj4KZW5kb2JqCjcgMCBvYmoKPDwgL1R5cGUgL0NhdGFsb2cKICAgL1BhZ2VzIDEgMCBSCj4+CmVuZG9iagp4cmVmCjAgOAowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDA1ODAgMDAwMDAgbiAKMDAwMDAwMDI1MiAwMDAwMCBuIAowMDAwMDAwMDE1IDAwMDAwIG4gCjAwMDAwMDAyMzAgMDAwMDAgbiAKMDAwMDAwMDM2NiAwMDAwMCBuIAowMDAwMDAwNjQ1IDAwMDAwIG4gCjAwMDAwMDA3NzIgMDAwMDAgbiAKdHJhaWxlcgo8PCAvU2l6ZSA4CiAgIC9Sb290IDcgMCBSCiAgIC9JbmZvIDYgMCBSCj4+CnN0YXJ0eHJlZgo4MjQKJSVFT0YK',
-      ],
+      pdfList: [],
       src:'',
       loadedRatio: 0,
       page: 1,
@@ -86,6 +78,7 @@ export default{
     // console.log('Created----' + this.query)
     this.parseQuery()
     this.fetchData()
+    pdfList.clear()
   },
 
   watch: {


### PR DESCRIPTION
The search cards will now link to the attached PDF
The PDF viewer will now show the attached PDF if stored properly in static
The search cards now display matches across all metrics
The search cards now allow viewing of meta data such as attendees and items